### PR TITLE
analyzer-driver: use default depth from config

### DIFF
--- a/litescope/software/driver/analyzer.py
+++ b/litescope/software/driver/analyzer.py
@@ -91,7 +91,9 @@ class LiteScopeAnalyzerDriver:
     def configure_subsampler(self, value):
         self.subsampler_value.write(value-1)
 
-    def run(self, offset, length):
+    def run(self, offset = 0, length = None):
+        if length is None:
+            length = self.depth
         assert offset < self.depth
         assert length <= self.depth
         if self.debug:


### PR DESCRIPTION
The configuration already knows what the default depth is, so just use
the default depth from there.

Also set the default offset to 0, since that is frequently a good default.

Signed-off-by: Sean Cross <sean@xobs.io>