### PR TITLE
Use cpu instead of cpu_or_bridge in examples

### DIFF
--- a/examples/targets/core.py
+++ b/examples/targets/core.py
@@ -56,7 +56,7 @@ class Core(SoCCore):
             with_timer=False
         )
         self.add_cpu_or_bridge(UARTWishboneBridge(platform.request("serial"), clk_freq, baudrate=115200))
-        self.add_wb_master(self.cpu_or_bridge.wishbone)
+        self.add_wb_master(self.cpu.wishbone)
 
         self.bus = platform.request("bus")
         self.submodules.analyzer = LiteScopeAnalyzer((self.bus), 512)

--- a/examples/targets/simple.py
+++ b/examples/targets/simple.py
@@ -32,7 +32,7 @@ class LiteScopeSoC(SoCCore):
         # bridge
         self.add_cpu_or_bridge(UARTWishboneBridge(platform.request("serial"),
             sys_clk_freq, baudrate=115200))
-        self.add_wb_master(self.cpu_or_bridge.wishbone)
+        self.add_wb_master(self.cpu.wishbone)
 
         # Litescope IO
         self.submodules.io = LiteScopeIO(8)


### PR DESCRIPTION
Fix LiteX dropping compatibility in enjoy-digital/litex@7f0d116d8876dde1f602927a0a2c4885f339524e. 
