### PR TITLE
Fix: A WaitTimer belongs to the wrong clock domain (trigger flush)

### DIFF
--- a/litescope/core.py
+++ b/litescope/core.py
@@ -73,6 +73,7 @@ class _Trigger(Module, AutoCSR):
         # Hit and memory read/flush
         hit   = Signal()
         flush = WaitTimer(2*depth)
+        flush = ClockDomainsRenamer("scope")(flush)
         self.submodules += flush
         self.comb += [
             flush.wait.eq(~(~enable & enable_d)), # flush when disabling


### PR DESCRIPTION
I think the WaitTimer for the trigger flush should belong to the scope clock instead of the sys clock.