### PR TITLE
Fix: 2 signals in the storage class belong to the wrong clock domain

### DIFF
--- a/litescope/core.py
+++ b/litescope/core.py
@@ -208,11 +208,11 @@ class _Storage(Module, AutoCSR):
             If(sink.valid & sink.hit,
                 NextState("RUN")
             ),
-            mem.source.ready.eq(mem.level >= self.offset.storage)
+            mem.source.ready.eq(mem.level >= offset)
         )
         fsm.act("RUN",
             sink.connect(mem.sink, omit={"hit"}),
-            If(mem.level >= self.length.storage,
+            If(mem.level >= length,
                 NextState("IDLE"),
             )
         )


### PR DESCRIPTION
Signals & Domain overview:
  - self.{offset,length}.storage belong to sys clock
  - offset, length belong to scope clock
  - mem belongs to scope clock

Therefore, everything that involves mem needs to use offset/length