### PR TITLE
litescope/core: add option to register input signals to cut timings

### DIFF
--- a/litescope/core.py
+++ b/litescope/core.py
@@ -226,7 +226,7 @@ class _Storage(Module, AutoCSR):
 
 
 class LiteScopeAnalyzer(Module, AutoCSR):
-    def __init__(self, groups, depth, clock_domain="sys", trigger_depth=16, csr_csv="analyzer.csv"):
+    def __init__(self, groups, depth, clock_domain="sys", trigger_depth=16, register=0, csr_csv="analyzer.csv"):
         self.groups = groups = self.format_groups(groups)
         self.depth  = depth
 
@@ -242,10 +242,16 @@ class LiteScopeAnalyzer(Module, AutoCSR):
 
         # Mux
         self.submodules.mux = _Mux(data_width, len(groups))
+        sd = getattr(self.sync, clock_domain)
         for i, signals in groups.items():
+            s = Cat(signals)
+            for _ in range(register):
+                s_d = Signal(len(s))
+                sd += s_d.eq(s)
+                s = s_d
             self.comb += [
                 self.mux.sinks[i].valid.eq(1),
-                self.mux.sinks[i].data.eq(Cat(signals))
+                self.mux.sinks[i].data.eq(s)
             ]
 
         # Frontend


### PR DESCRIPTION
This change allows to easily cut timings and the introduced delay shouldn't have an effect on logic analyzer operation. I could observe ~40 sec build time improvements for ~7 minute builds when using a wide signals bus with >700 bits, but this will most likely depend on which signals are being sampled.