### PR TITLE
Fix the cli error messages to make it clearer when you need to provide more CSVs

### DIFF
--- a/litescope/software/driver/analyzer.py
+++ b/litescope/software/driver/analyzer.py
@@ -94,7 +94,7 @@ class LiteScopeAnalyzerDriver:
                         v <<= 4 if mx is not None else 1
                         m <<= 4 if mx is not None else 1
                         if c != "x":
-                            v |= int(c, 16 if mx is not None else 2)
+                            v |= int(c, 16 if mx is not None else 2 )
                             m |= 0xf if mx is not None else 0b1
                     value |= getattr(self, k + "_o")*v
                     mask  |= getattr(self, k + "_m") & (getattr(self, k + "_o")*m)

--- a/litescope/software/driver/analyzer.py
+++ b/litescope/software/driver/analyzer.py
@@ -94,7 +94,7 @@ class LiteScopeAnalyzerDriver:
                         v <<= 4 if mx is not None else 1
                         m <<= 4 if mx is not None else 1
                         if c != "x":
-                            v |= int(c)
+                            v |= int(c, 16 if mx is not None else 2)
                             m |= 0xf if mx is not None else 0b1
                     value |= getattr(self, k + "_o")*v
                     mask  |= getattr(self, k + "_m") & (getattr(self, k + "_o")*m)

--- a/litescope/software/litescope_cli.py
+++ b/litescope/software/litescope_cli.py
@@ -135,7 +135,7 @@ def main():
         analyzer.upload()
         analyzer.save(args.dump)
 
-    # Close remove control.M#
+    # Close remove control.
     finally:
         bus.close()
 

--- a/litescope/software/litescope_cli.py
+++ b/litescope/software/litescope_cli.py
@@ -84,6 +84,7 @@ def parse_args():
         metavar=("TRIGGER", "VALUE"))
     parser.add_argument("-l", "--list",          action="store_true",      help="List signal choices")
     parser.add_argument("--csv",                 default="analyzer.csv",   help="Analyzer CSV file")
+    parser.add_argument("--csr-csv",             default="csr.csv",        help="SoC CSV file")
     parser.add_argument("--group",               default="0",              help="Capture Group")
     parser.add_argument("--subsampling",         default="1",              help="Capture Subsampling")
     parser.add_argument("--offset",              default="32",             help="Capture Offset")
@@ -99,7 +100,8 @@ def main():
 
     # Check if analyzer file is present and exit if not.
     if not os.path.exists(args.csv):
-        raise ValueError("{} not found, exiting.".format(args.csv))
+        raise ValueError("{} not found. This is necessary to load the wires which have been tapped to scope."
+                         "Try setting --csv to value of the csr_csv argument to LiteScopeAnalyzer in the SoC.".format(args.csv))
         sys.exit(1)
 
     # Get list of signals from analyzer configuratio file.
@@ -112,7 +114,10 @@ def main():
         sys.exit(0)
 
     # Create and open remote control.
-    bus = RemoteClient()
+    if not os.path.exists(args.csr_csv):
+        raise ValueError("{} not found. This is necessary to load the 'regs' of the remote. Try setting --csr-csv here to "
+                         "the path to the --csr-csv argument of the SoC build.".format(args.csr_csv))
+    bus = RemoteClient(csr_csv=args.csr_csv)
     bus.open()
 
     # Configure and run LiteScope analyzer.
@@ -130,7 +135,7 @@ def main():
         analyzer.upload()
         analyzer.save(args.dump)
 
-    # Close remove control.
+    # Close remove control.M#
     finally:
         bus.close()
 

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -15,5 +15,4 @@ class TestExamples(unittest.TestCase):
     def test_arty(self):
         os.system(f"rm -rf {root_dir}/build")
         os.system(f"cd {root_dir}/examples && python3 arty.py")
-        self.assertEqual(os.path.isfile(f"{root_dir}/examples/build/arty/gateware/arty.v"), True)
-
+        self.assertEqual(os.path.isfile(f"{root_dir}/examples/build/digilent_arty/gateware/digilent_arty.v"), True)


### PR DESCRIPTION
The SoC CSR CSV is in fact required, but was defaulting to `csr.csv`.  This was made more confusing by the error message which was complaining about an absence of regs.  

Also, fix the trigger value parsing for hex values.