### PR TITLE
Fix hex value trigger

### DIFF
--- a/litescope/software/driver/analyzer.py
+++ b/litescope/software/driver/analyzer.py
@@ -94,7 +94,7 @@ class LiteScopeAnalyzerDriver:
                         v <<= 4 if mx is not None else 1
                         m <<= 4 if mx is not None else 1
                         if c != "x":
-                            v |= int(c)
+                            v |= int(c,16)
                             m |= 0xf if mx is not None else 0b1
                     value |= getattr(self, k + "_o")*v
                     mask  |= getattr(self, k + "_m") & (getattr(self, k + "_o")*m)


### PR DESCRIPTION
When using `a-f` in litescope_cli the conversion to integer fails due to the base being 10 instead of 16.
This should fix it.

```
$ litescope_cli -v main_basesoc_blackparrotrv64_pc 0xxxxxxxxa7c -v main_basesoc_blackparrotrv64_instr 0xf4737
Exact: main_basesoc_blackparrotrv64_pc
Exact: main_basesoc_blackparrotrv64_pc
Condition: main_basesoc_blackparrotrv64_pc == 0xxxxxxxxa7c
Exact: main_basesoc_blackparrotrv64_instr
Exact: main_basesoc_blackparrotrv64_instr
Condition: main_basesoc_blackparrotrv64_instr == 0xf4737
Traceback (most recent call last):
  File "/home/martin/.local/bin/litescope_cli", line 11, in <module>
    load_entry_point('litescope', 'console_scripts', 'litescope_cli')()
  File "/home/martin/coding/litex/litescope/litescope/software/litescope_cli.py", line 123, in main
    if not add_triggers(args, analyzer, signals):
  File "/home/martin/coding/litex/litescope/litescope/software/litescope_cli.py", line 73, in add_triggers
    analyzer.add_trigger(cond=cond)
  File "/home/martin/coding/litex/litescope/litescope/software/driver/analyzer.py", line 97, in add_trigger
    v |= int(c)
ValueError: invalid literal for int() with base 10: 'a'
```