### PR TITLE
VCD: Add samplerate support to fix displayed timestamps

### DIFF
--- a/examples/arty.py
+++ b/examples/arty.py
@@ -48,6 +48,7 @@ class LiteScopeSoC(BaseSoC):
         self.submodules.analyzer = LiteScopeAnalyzer(analyzer_signals,
             depth        = 1024,
             clock_domain = "sys",
+            samplerate   = self.sys_clk_freq,
             csr_csv      = "analyzer.csv")
         self.add_csr("analyzer")
 

--- a/litescope/core.py
+++ b/litescope/core.py
@@ -226,9 +226,10 @@ class _Storage(Module, AutoCSR):
 
 
 class LiteScopeAnalyzer(Module, AutoCSR):
-    def __init__(self, groups, depth, clock_domain="sys", trigger_depth=16, register=False, csr_csv="analyzer.csv"):
-        self.groups = groups = self.format_groups(groups)
-        self.depth  = depth
+    def __init__(self, groups, depth, samplerate=1e-12, clock_domain="sys", trigger_depth=16, register=False, csr_csv="analyzer.csv"):
+        self.groups     = groups = self.format_groups(groups)
+        self.depth      = depth
+        self.samplerate = samplerate
 
         self.data_width = data_width = max([sum([len(s) for s in g]) for g in groups.values()])
 
@@ -294,6 +295,7 @@ class LiteScopeAnalyzer(Module, AutoCSR):
             return ",".join(args) + "\n"
         r = format_line("config", "None", "data_width", str(self.data_width))
         r += format_line("config", "None", "depth", str(self.depth))
+        r += format_line("config", "None", "samplerate", str(self.samplerate))
         for i, signals in self.groups.items():
             for s in signals:
                 r += format_line("signal", str(i), vns.get_name(s), str(len(s)))

--- a/litescope/software/driver/analyzer.py
+++ b/litescope/software/driver/analyzer.py
@@ -118,6 +118,7 @@ class LiteScopeAnalyzerDriver:
         self.add_trigger(value, mask, cond)
 
     def configure_subsampler(self, value):
+        self.subsampling = value
         self.subsampler_value.write(value-1)
 
     def run(self, offset=0, length=None):
@@ -166,11 +167,13 @@ class LiteScopeAnalyzerDriver:
         return self.data
 
     def save(self, filename, samplerate=None, flatten=False):
+        if samplerate is None:
+            samplerate = self.samplerate / self.subsampling
         if self.debug:
             print("[writing to " + filename + "]...")
         name, ext = os.path.splitext(filename)
         if ext == ".vcd":
-            dump = VCDDump()
+            dump = VCDDump(samplerate=samplerate)
         elif ext == ".csv":
             dump = CSVDump()
         elif ext == ".py":


### PR DESCRIPTION
To use this, pass the samplerate kwarg to LiteScopeAnalyzer(). If using the sys domain, soc_obj.sys_clk_freq works.