### PR TITLE
software/litescope_cli: pass full path of csv file to driver.

### DIFF
--- a/litescope/software/litescope_cli.py
+++ b/litescope/software/litescope_cli.py
@@ -86,7 +86,7 @@ def run_batch(args):
     signals  = get_signals(args.csv, args.group)
 
     # Configure and run LiteScope analyzer.
-    analyzer = LiteScopeAnalyzerDriver(bus.regs, basename, debug=True)
+    analyzer = LiteScopeAnalyzerDriver(bus.regs, basename, config_csv=args.csv, debug=True)
     analyzer.configure_group(args.group)
     analyzer.configure_subsampler(args.subsampling)
     if not add_triggers(args, analyzer, signals):
@@ -112,7 +112,7 @@ def run_gui(args):
 
     def capture_callback():
         basename = os.path.splitext(os.path.basename(args.csv))[0]
-        analyzer = LiteScopeAnalyzerDriver(bus.regs, basename, debug=True)
+        analyzer = LiteScopeAnalyzerDriver(bus.regs, basename, config_csv=args.csv, debug=True)
         analyzer.configure_group(int(dpg.get_value(item="capture_group"), 0))
         analyzer.configure_subsampler(int(dpg.get_value(item="capture_subsampling"), 0))
         trigger_cond = {}


### PR DESCRIPTION
Without this fix the driver only gets the basename of the csv, and is unable to find it if it is not in the current directory.