### PR TITLE
Fix VCD scope declarations (#47)

### DIFF
--- a/litescope/software/dump/vcd.py
+++ b/litescope/software/dump/vcd.py
@@ -89,7 +89,7 @@ class VCDDump(Dump):
         return r
 
     def generate_vars(self):
-        r = "$scope dumped_signals $end\n"
+        r = "$scope module top $end\n"
         for v in self.variables:
             r += "$var wire "
             r += str(v.width)
@@ -98,7 +98,7 @@ class VCDDump(Dump):
             r += " "
             r += v.name
             r += " $end\n"
-        r += "$unscope "
+        r += "$upscope "
         r += " $end\n"
         r += "$enddefinitions "
         r += " $end\n"


### PR DESCRIPTION
This PR addresses the VCD scope declaration issues described in #47, which I also encountered.

Based on @ozel's detailed analysis in #47, the following changes have been applied:
* Scope Declaration: Updated from ```$scope dumped_signals $end``` to ```$scope module top $end```
* Scope End Tag: Corrected from ```$unscope``` to ```$upscope```

These changes conform with the IEEE standard.


Please review these changes and let me know if further adjustments are needed.