### PR TITLE
litescope/software/dump: Fix invalid escape sequences in regex strings.

### DIFF
--- a/litescope/software/dump/sigrok.py
+++ b/litescope/software/dump/sigrok.py
@@ -109,7 +109,7 @@ unitsize={}
         probes = OrderedDict()
         f = open("metadata", "r")
         for l in f:
-            m = re.search("probe([0-9]+) = (\w+)", l, re.I)
+            m = re.search(r"probe([0-9]+) = (\w+)", l, re.I)
             if m is not None:
                 index = int(m.group(1))
                 name = m.group(2)

--- a/litescope/software/dump/vcd.py
+++ b/litescope/software/dump/vcd.py
@@ -30,7 +30,7 @@ _si_prefix2exp = {
 }
 
 def _timescale_str2num(timescale):
-    match = re.fullmatch("(\d+)(\w{0,1})s", timescale)
+    match = re.fullmatch(r"(\d+)(\w{0,1})s", timescale)
     num = int(match.group(1))
     si_prefix = match.group(2)
     exp = _si_prefix2exp[si_prefix]


### PR DESCRIPTION
Both files were missing the r prefix on regex strings. Python 3.12+ warns about \w and \d in non-raw strings since they look like invalid escape sequences (like \n, \t). A future Python version will make this an error.