### PR TITLE
analyzer: Add trigger sequence timeouts

### DIFF
--- a/litescope/core.py
+++ b/litescope/core.py
@@ -7,7 +7,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 from migen import *
-from migen.genlib.cdc import MultiReg, PulseSynchronizer
+from migen.genlib.cdc import MultiReg
 
 from litex.gen import *
 from litex.gen.genlib.misc import WaitTimer
@@ -42,58 +42,120 @@ def core_layout(data_width):
 # LiteScope Analyzer Trigger -----------------------------------------------------------------------
 
 class _Trigger(LiteXModule):
-    def __init__(self, data_width, depth=16):
+    def __init__(self, data_width, depth=16, timeout_width=32):
         self.sink   = sink   = stream.Endpoint(core_layout(data_width))
         self.source = source = stream.Endpoint(core_layout(data_width))
 
         self.enable = CSRStorage()
         self.done   = CSRStatus()
 
-        self.mem_write = CSR()
-        self.mem_mask  = CSRStorage(data_width)
-        self.mem_value = CSRStorage(data_width)
-        self.mem_full  = CSRStatus()
+        self.mem_write   = CSR()
+        self.mem_reset   = CSR()
+        self.mem_mask    = CSRStorage(data_width)
+        self.mem_value   = CSRStorage(data_width)
+        self.mem_timeout = CSRStorage(timeout_width)
+        self.mem_full    = CSRStatus()
 
         # # #
 
         # Control re-synchronization.
         enable   = Signal()
-        enable_d = Signal()
         self.specials += MultiReg(self.enable.storage, enable, "scope")
-        self.sync.scope += enable_d.eq(enable)
 
         # Status re-synchronization.
         done = Signal()
         self.specials += MultiReg(done, self.done.status)
 
         # Memory and configuration.
-        mem = stream.AsyncFIFO([("mask", data_width), ("value", data_width)], depth)
-        mem = ClockDomainsRenamer({"write": "sys", "read": "scope"})(mem)
-        self.submodules += mem
+        entry_width = 2*data_width + timeout_width
+        mem         = Memory(entry_width, depth)
+        self.specials += mem
+
+        wrport = mem.get_port(write_capable=True, clock_domain="sys")
+        rdport = mem.get_port(async_read=True, clock_domain="scope")
+        self.specials += wrport, rdport
+
+        write_count = Signal(max=depth + 1)
+        write_ptr   = Signal(max=depth)
+        write       = Signal()
         self.comb += [
-            mem.sink.valid.eq(self.mem_write.wr_stb),
-            mem.sink.mask.eq(self.mem_mask.storage),
-            mem.sink.value.eq(self.mem_value.storage),
-            self.mem_full.status.eq(~mem.sink.ready)
+            write.eq(self.mem_write.wr_stb & (write_count != depth)),
+            wrport.we.eq(write),
+            wrport.adr.eq(write_ptr),
+            wrport.dat_w.eq(Cat(
+                self.mem_mask.storage,
+                self.mem_value.storage,
+                self.mem_timeout.storage)),
+            self.mem_full.status.eq(write_count == depth),
+        ]
+        self.sync += [
+            If(self.mem_reset.wr_stb,
+                write_count.eq(0),
+                write_ptr.eq(0)
+            ).Elif(write,
+                write_count.eq(write_count + 1),
+                write_ptr.eq(write_ptr + 1)
+            )
         ]
 
-        # Hit and memory read/flush.
-        hit   = Signal()
-        flush = WaitTimer(2*depth)
-        flush = ClockDomainsRenamer("scope")(flush)
-        self.submodules += flush
+        trigger_count = Signal(max=depth + 1)
+        self.specials += MultiReg(write_count, trigger_count, "scope")
+
+        # Trigger sequence.
+        trigger_index = Signal(max=depth)
+        mask          = Signal(data_width)
+        value         = Signal(data_width)
+        timeout       = Signal(timeout_width)
+        timeout_count = Signal(timeout_width)
+        entry_valid   = Signal()
+        hit           = Signal()
+        last          = Signal()
+        final_hit     = Signal()
+        timeout_hit   = Signal()
+        sample        = Signal()
+
         self.comb += [
-            flush.wait.eq(~(~enable & enable_d)), # flush when disabling
-            hit.eq((sink.data & mem.source.mask) == (mem.source.value & mem.source.mask)),
-            mem.source.ready.eq((enable & hit) | ~flush.done),
+            rdport.adr.eq(trigger_index),
+            mask.eq(rdport.dat_r[:data_width]),
+            value.eq(rdport.dat_r[data_width:2*data_width]),
+            timeout.eq(rdport.dat_r[2*data_width:]),
+            entry_valid.eq(trigger_index < trigger_count),
+            hit.eq(entry_valid & ((sink.data & mask) == (value & mask))),
+            last.eq(trigger_index == (trigger_count - 1)),
+            final_hit.eq(enable & sink.valid & hit & last),
+            timeout_hit.eq(entry_valid & (timeout != 0) & (timeout_count == (timeout - 1))),
+            sample.eq(enable & sink.valid & source.ready),
+        ]
+
+        self.sync.scope += [
+            If(~enable,
+                trigger_index.eq(0),
+                timeout_count.eq(0),
+                done.eq(0)
+            ).Elif(done,
+                timeout_count.eq(0)
+            ).Elif(sample & entry_valid,
+                If(hit,
+                    timeout_count.eq(0),
+                    If(last,
+                        trigger_index.eq(0),
+                        done.eq(1)
+                    ).Else(
+                        trigger_index.eq(trigger_index + 1)
+                    )
+                ).Elif(timeout_hit,
+                    trigger_index.eq(0),
+                    timeout_count.eq(0)
+                ).Elif(timeout != 0,
+                    timeout_count.eq(timeout_count + 1)
+                )
+            )
         ]
 
         # Output.
         self.comb += [
             sink.connect(source),
-            # Done when all triggers have been consumed.
-            done.eq(~mem.source.valid),
-            source.hit.eq(done)
+            source.hit.eq((trigger_count == 0) | done | final_hit),
         ]
 
 # LiteScope Analyzer SubSampler --------------------------------------------------------------------
@@ -365,18 +427,20 @@ class _Storage(LiteXModule):
 
 class LiteScopeAnalyzer(LiteXModule):
     def __init__(self, groups, depth,
-        samplerate       = 1e12,
-        clock_domain     = "sys",
-        trigger_depth    = 16,
-        subsampler_width = 16,
-        register         = False,
-        with_rle         = False,
-        rle_length       = 256,
-        csr_csv          = "analyzer.csv",
+        samplerate             = 1e12,
+        clock_domain           = "sys",
+        trigger_depth          = 16,
+        trigger_timeout_width  = 32,
+        subsampler_width       = 16,
+        register               = False,
+        with_rle               = False,
+        rle_length             = 256,
+        csr_csv                = "analyzer.csv",
     ):
         self.groups           = groups = self.format_groups(groups)
         self.depth            = depth
         self.samplerate       = int(samplerate)
+        self.trigger_timeout_width = trigger_timeout_width
         self.subsampler_width = subsampler_width
 
         self.data_width = data_width = max([sum([len(s) for s in g]) for g in groups.values()])
@@ -413,7 +477,7 @@ class LiteScopeAnalyzer(LiteXModule):
 
         # Frontend.
         # ---------
-        self.trigger    = _Trigger(data_width, depth=trigger_depth)
+        self.trigger    = _Trigger(data_width, depth=trigger_depth, timeout_width=trigger_timeout_width)
         self.subsampler = _SubSampler(data_width, value_width=subsampler_width)
 
         # Storage.
@@ -468,6 +532,7 @@ class LiteScopeAnalyzer(LiteXModule):
         r += format_line("config", "None", "storage_width", str(self.storage_width))
         r += format_line("config", "None", "depth", str(self.depth))
         r += format_line("config", "None", "samplerate", str(self.samplerate))
+        r += format_line("config", "None", "trigger_timeout_width", str(self.trigger_timeout_width))
         r += format_line("config", "None", "subsampler_width", str(self.subsampler_width))
         r += format_line("config", "None", "with_rle", str(int(self.with_rle)))
         r += format_line("config", "None", "rle_length", str(self.rle_length))

--- a/litescope/software/driver/analyzer.py
+++ b/litescope/software/driver/analyzer.py
@@ -72,6 +72,8 @@ class LiteScopeAnalyzerDriver:
         self.length = None
 
         # Disable trigger and storage
+        if hasattr(self, "trigger_mem_reset"):
+            self.trigger_mem_reset.write(1)
         self.trigger_enable.write(0)
         self.storage_enable.write(0)
         if hasattr(self, "rle_enable"):
@@ -88,7 +90,8 @@ class LiteScopeAnalyzerDriver:
         self.storage_width     = getattr(self, "storage_width", self.data_width)
         self.with_rle          = getattr(self, "with_rle", 0)
         self.rle_length        = getattr(self, "rle_length", 0)
-        self.subsampler_width = getattr(self, "subsampler_width", 16)
+        self.trigger_timeout_width = getattr(self, "trigger_timeout_width", 32)
+        self.subsampler_width      = getattr(self, "subsampler_width", 16)
 
     def get_layouts(self):
         self.layouts = {}
@@ -126,9 +129,14 @@ class LiteScopeAnalyzerDriver:
         self.group = value
         self.mux_value.write(value)
 
-    def add_trigger(self, value=0, mask=0, cond=None):
+    def add_trigger(self, value=0, mask=0, cond=None, timeout=0):
         if self.trigger_mem_full.read():
             raise ValueError("Trigger memory full, too much conditions")
+        timeout = 0 if timeout is None else timeout
+        if timeout < 0:
+            raise ValueError("Trigger timeout must be >= 0")
+        if timeout >= 2**self.trigger_timeout_width:
+            raise ValueError("Trigger timeout must be < 2**{:d}".format(self.trigger_timeout_width))
         if cond is not None:
             for k, v in cond.items():
                 # Check for binary/hexa expressions
@@ -153,6 +161,8 @@ class LiteScopeAnalyzerDriver:
                     mask  |= getattr(self, k + "_m")
         self.trigger_mem_mask.write(mask)
         self.trigger_mem_value.write(value)
+        if hasattr(self, "trigger_mem_timeout"):
+            self.trigger_mem_timeout.write(timeout)
         self.trigger_mem_write.write(1)
 
     def add_rising_edge_trigger(self, name):
@@ -163,8 +173,8 @@ class LiteScopeAnalyzerDriver:
         self.add_trigger(getattr(self, name + "_o")*1, getattr(self, name + "_m"))
         self.add_trigger(getattr(self, name + "_o")*0, getattr(self, name + "_m"))
 
-    def configure_trigger(self, value=0, mask=0, cond=None):
-        self.add_trigger(value, mask, cond)
+    def configure_trigger(self, value=0, mask=0, cond=None, timeout=0):
+        self.add_trigger(value, mask, cond, timeout=timeout)
 
     def configure_subsampler(self, value):
         if value < 1:
@@ -203,6 +213,8 @@ class LiteScopeAnalyzerDriver:
         self.offset = 0
         self.length = None
         self.rle_enabled = False
+        if hasattr(self, "trigger_mem_reset"):
+            self.trigger_mem_reset.write(1)
         self.trigger_enable.write(0)
         self.storage_enable.write(0)
         if hasattr(self, "rle_enable"):

--- a/test/test_analyzer.py
+++ b/test/test_analyzer.py
@@ -10,6 +10,7 @@ import tempfile
 from migen import *
 
 from litescope import LiteScopeAnalyzer
+from litescope.core import _Trigger
 from litescope.software.dump.common import DumpData
 
 
@@ -29,7 +30,62 @@ def read_capture_words(analyzer, length):
     return data
 
 
+def configure_trigger_entry(trigger, value, mask, timeout=0):
+    yield from trigger.mem_value.write(value)
+    yield from trigger.mem_mask.write(mask)
+    yield from trigger.mem_timeout.write(timeout)
+    yield from trigger.mem_write.write(1)
+
+
 class TestAnalyzer(unittest.TestCase):
+    def run_trigger_sequence(self, entries, samples):
+        def generator(dut):
+            dut.hits = []
+            for value, mask, timeout in entries:
+                yield from configure_trigger_entry(dut.trigger, value, mask, timeout)
+            for i in range(16):
+                yield
+
+            yield from dut.trigger.enable.write(1)
+            yield dut.trigger.sink.valid.eq(1)
+            yield dut.trigger.source.ready.eq(1)
+            yield
+
+            for sample in samples:
+                yield dut.trigger.sink.data.eq(sample)
+                yield
+                dut.hits.append((yield dut.trigger.source.hit))
+
+        class DUT(Module):
+            def __init__(self):
+                self.submodules.trigger = _Trigger(8, depth=4, timeout_width=4)
+
+        dut = DUT()
+        generators = {"sys" : [generator(dut)]}
+        clocks     = {"sys": 10, "scope": 10}
+        run_simulation(dut, generators, clocks)
+        return dut.hits
+
+    def test_trigger_timeout_restarts_sequence(self):
+        hits = self.run_trigger_sequence(
+            entries = [
+                (1, 0xff, 0),
+                (2, 0xff, 3),
+            ],
+            samples = [1, 0, 0, 0, 2, 1, 0, 2],
+        )
+        self.assertEqual(hits, [0, 0, 0, 0, 0, 0, 0, 1])
+
+    def test_trigger_zero_timeout_waits_indefinitely(self):
+        hits = self.run_trigger_sequence(
+            entries = [
+                (1, 0xff, 0),
+                (2, 0xff, 0),
+            ],
+            samples = [1, 0, 0, 0, 0, 2],
+        )
+        self.assertEqual(hits, [0, 0, 0, 0, 0, 1])
+
     def test_analyzer(self):
         def generator(dut):
             dut.data = []
@@ -45,6 +101,7 @@ class TestAnalyzer(unittest.TestCase):
             yield from dut.analyzer.storage.length.write(256)
             yield from dut.analyzer.storage.offset.write(8)
             yield from dut.analyzer.storage.enable.write(1)
+            yield from dut.analyzer.trigger.enable.write(1)
             yield
             for i in range(16):
                 yield
@@ -71,7 +128,7 @@ class TestAnalyzer(unittest.TestCase):
             yield from dut.analyzer.mux.value.write(1)
 
             # Trigger on the second group and verify captured data comes from it.
-            yield from dut.analyzer.trigger.mem_value.write(0xb0)
+            yield from dut.analyzer.trigger.mem_value.write(0xb2)
             yield from dut.analyzer.trigger.mem_mask.write(0xff)
             yield from dut.analyzer.trigger.mem_write.write(1)
 
@@ -105,7 +162,7 @@ class TestAnalyzer(unittest.TestCase):
         generators = {"sys" : [generator(dut)]}
         clocks     = {"sys": 10, "scope": 10}
         run_simulation(dut, generators, clocks)
-        self.assertEqual(dut.data, [132 + 3*i for i in range(len(dut.data))])
+        self.assertEqual(dut.data, [175 + 3*i for i in range(len(dut.data))])
 
     def test_analyzer_raw_msb_data_without_rle(self):
         def generator(dut):
@@ -327,6 +384,7 @@ class TestAnalyzer(unittest.TestCase):
             "config,None,storage_width,5",
             "config,None,depth,32",
             "config,None,samplerate,125000000",
+            "config,None,trigger_timeout_width,32",
             "config,None,subsampler_width,20",
             "config,None,with_rle,0",
             "config,None,rle_length,256",

--- a/test/test_driver.py
+++ b/test/test_driver.py
@@ -40,7 +40,8 @@ class FakeRegs:
 
 
 def write_config(filename, data_width=8, depth=16, samplerate=100000000,
-                 storage_width=None, subsampler_width=None,
+                 storage_width=None, trigger_timeout_width=None,
+                 subsampler_width=None,
                  with_rle=None, rle_length=None, enums=None):
     with open(filename, "w") as f:
         f.write(f"config,None,data_width,{data_width}\n")
@@ -48,6 +49,8 @@ def write_config(filename, data_width=8, depth=16, samplerate=100000000,
             f.write(f"config,None,storage_width,{storage_width}\n")
         f.write(f"config,None,depth,{depth}\n")
         f.write(f"config,None,samplerate,{samplerate}\n")
+        if trigger_timeout_width is not None:
+            f.write(f"config,None,trigger_timeout_width,{trigger_timeout_width}\n")
         if subsampler_width is not None:
             f.write(f"config,None,subsampler_width,{subsampler_width}\n")
         if with_rle is not None:
@@ -66,8 +69,10 @@ def make_regs(name="analyzer", mem_level=0, mem_data=None, with_rle=False):
     regs = {
         "mux_value":             FakeReg(),
         "trigger_mem_full":      FakeReg(),
+        "trigger_mem_reset":     FakeReg(),
         "trigger_mem_mask":      FakeReg(),
         "trigger_mem_value":     FakeReg(),
+        "trigger_mem_timeout":   FakeReg(),
         "trigger_mem_write":     FakeReg(),
         "trigger_enable":        FakeReg(),
         "subsampler_value":      FakeReg(),
@@ -122,18 +127,20 @@ def pack_storage_words(words, storage_width):
 
 class TestAnalyzerDriver(unittest.TestCase):
     def make_driver(self, data_width=8, depth=16, mem_level=0, mem_data=None,
-                    storage_width=None, subsampler_width=None,
+                    storage_width=None, trigger_timeout_width=None,
+                    subsampler_width=None,
                     with_rle=False, rle_length=256, enums=None):
         self.tmpdir = tempfile.TemporaryDirectory()
         config_csv  = os.path.join(self.tmpdir.name, "analyzer.csv")
         write_config(config_csv,
-            data_width       = data_width,
-            depth            = depth,
-            storage_width    = storage_width,
-            subsampler_width = subsampler_width,
-            with_rle         = with_rle if with_rle else None,
-            rle_length       = rle_length if with_rle else None,
-            enums            = enums)
+            data_width            = data_width,
+            depth                 = depth,
+            storage_width         = storage_width,
+            trigger_timeout_width = trigger_timeout_width,
+            subsampler_width      = subsampler_width,
+            with_rle              = with_rle if with_rle else None,
+            rle_length            = rle_length if with_rle else None,
+            enums                 = enums)
         regs = make_regs(mem_level=mem_level, mem_data=mem_data, with_rle=with_rle)
         driver = LiteScopeAnalyzerDriver(regs, "analyzer", config_csv=config_csv)
         return driver, regs
@@ -153,6 +160,7 @@ class TestAnalyzerDriver(unittest.TestCase):
         self.assertEqual(driver.storage_width, 8)
         self.assertEqual(driver.depth, 16)
         self.assertEqual(driver.samplerate, 100000000)
+        self.assertEqual(driver.trigger_timeout_width, 32)
         self.assertEqual(driver.subsampler_width, 16)
         self.assertEqual(driver.with_rle, 0)
         self.assertEqual(driver.layouts, {
@@ -165,6 +173,7 @@ class TestAnalyzerDriver(unittest.TestCase):
         self.assertEqual(driver.state_m, 0xe)
         self.assertEqual(driver.wide_o,  0x1)
         self.assertEqual(driver.wide_m,  0xff)
+        self.assertEqual(regs.d["analyzer_trigger_mem_reset"].writes, [1])
         self.assertEqual(regs.d["analyzer_trigger_enable"].writes, [0])
         self.assertEqual(regs.d["analyzer_storage_enable"].writes, [0])
 
@@ -195,17 +204,19 @@ class TestAnalyzerDriver(unittest.TestCase):
 
         self.assertFalse(driver.rle_enabled)
         self.assertEqual(regs.d["analyzer_rle_enable"].writes, [1, 0])
+        self.assertEqual(regs.d["analyzer_trigger_mem_reset"].writes, [1])
         self.assertEqual(regs.d["analyzer_trigger_enable"].writes, [0])
         self.assertEqual(regs.d["analyzer_storage_enable"].writes, [0])
 
     def test_conditional_trigger_parsing(self):
-        driver, regs = self.make_driver()
+        driver, regs = self.make_driver(trigger_timeout_width=8)
         self.clear_writes(regs)
 
-        driver.add_trigger(cond={"flag": "1", "state": "0b1x0"})
+        driver.add_trigger(cond={"flag": "1", "state": "0b1x0"}, timeout=5)
 
         self.assertEqual(regs.d["analyzer_trigger_mem_value"].writes, [0x9])
         self.assertEqual(regs.d["analyzer_trigger_mem_mask"].writes,  [0xb])
+        self.assertEqual(regs.d["analyzer_trigger_mem_timeout"].writes, [5])
         self.assertEqual(regs.d["analyzer_trigger_mem_write"].writes, [1])
 
         self.clear_writes(regs)
@@ -213,7 +224,16 @@ class TestAnalyzerDriver(unittest.TestCase):
 
         self.assertEqual(regs.d["analyzer_trigger_mem_value"].writes, [0xa0])
         self.assertEqual(regs.d["analyzer_trigger_mem_mask"].writes,  [0xf0])
+        self.assertEqual(regs.d["analyzer_trigger_mem_timeout"].writes, [0])
         self.assertEqual(regs.d["analyzer_trigger_mem_write"].writes, [1])
+
+    def test_add_trigger_rejects_invalid_timeout(self):
+        driver, regs = self.make_driver(trigger_timeout_width=4)
+
+        with self.assertRaises(ValueError):
+            driver.add_trigger(value=1, mask=1, timeout=-1)
+        with self.assertRaises(ValueError):
+            driver.add_trigger(value=1, mask=1, timeout=16)
 
     def test_edge_trigger_helpers(self):
         driver, regs = self.make_driver()


### PR DESCRIPTION
Replace the destructive trigger FIFO with a small replayable trigger table so a sequence can restart from the first condition when a timed step expires.

Add an optional per-trigger timeout programmed through trigger_mem_timeout. A timeout of zero preserves the previous behavior and waits indefinitely for the next trigger condition.

Expose this through LiteScopeAnalyzerDriver.add_trigger(..., timeout=...) and export the trigger timeout width in analyzer.csv. Add simulations for timeout restart and zero-timeout compatibility.